### PR TITLE
Support X11 Connection Over Unix Socket

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -48,6 +48,24 @@
 						"description": "Screen number to connect to.",
 						"default": 0
 					},
+					"remoteX11.X11ConnectionType": {
+						"type": "string",
+						"description": "Sets how Remote X11 connects to the local X11 server.",
+						"default": "tcp",
+						"enum": [
+							"tcp",
+							"unix"
+						],
+						"markdownEnumDescriptions": [
+							"TCP connects to an X11 server listening on a local TCP socket.",
+							"Unix connects to an X11 server listening on a unix socket specified in `#remoteX11.X11Socket#`. This is generally nessasary for linux hosts."
+						]
+					},
+					"remoteX11.X11Socket": {
+						"type": "string",
+						"markdownDescription": "Path to the X11 server unix socket. The screen number specified in `#remoteX11.screen#` is appended to the end. Used when `#remoteX11.X11ConnectionType#` is set to unix. ",
+						"default": "/tmp/.X11-unix/X"
+					},
 					"remoteX11.SSH.enable": {
 						"type": "boolean",
 						"markdownDescription": "Enable X11 forwarding and set `DISPLAY` for SSH targets?",

--- a/ssh/src/config.ts
+++ b/ssh/src/config.ts
@@ -8,6 +8,8 @@ export const DefaultDisplayCommand = 'bash -c "echo DISPLAY=$DISPLAY"';
 
 export type AuthenticationMethod = 'agent' | 'keyFile';
 
+export type X11ConnectionMethod = 'tcp' | 'unix';
+
 export function getConfig<T>(name: string, defaultValue: T): T {
 	const config = vscode.workspace.getConfiguration('remoteX11');
 	return config.get(name, defaultValue);
@@ -51,6 +53,14 @@ export function getTimeout(): number {
 
 export function isVerboseLoggingEnabled(): boolean {
 	return getConfig('SSH.verboseLogging', false);
+}
+
+export function getX11ConnectionMethod(): X11ConnectionMethod {
+	return getConfig<X11ConnectionMethod>('X11ConnectionType', 'tcp');
+}
+
+export function getX11SocketPath(): string {
+	return getConfig('X11Socket', "/tmp/.X11-unix/X");
 }
 
 function getDefaultAgent(): string {

--- a/ssh/src/extension.ts
+++ b/ssh/src/extension.ts
@@ -14,6 +14,8 @@ import {
 	getServerHost,
 	getServerPort,
 	getDisplayCommand,
+	getX11ConnectionMethod,
+	getX11SocketPath,
 } from './config';
 import { Logger } from './logger';
 import { withTimeout } from './timeout';
@@ -112,7 +114,17 @@ function handleX11(info: X11Details, accept: () => ClientChannel) {
 		xclientsock.pipe(xserversock).pipe(xclientsock);
 	});
 
-	xserversock.connect(BASE_PORT + getDisplay(), 'localhost');
+	const method = getX11ConnectionMethod();
+	switch (method) {
+		case 'tcp':
+			xserversock.connect(BASE_PORT + getDisplay(), 'localhost');
+			break;
+		case 'unix':
+			xserversock.connect(getX11SocketPath() + getDisplay());
+			break;
+		default:
+			throw new Error(`Unknown connection method: ${method}.`);
+	}
 }
 
 function getAuthOptions(): Partial<ConnectConfig> {


### PR DESCRIPTION
Modern linux distro's don't support (by default) TCP connections to the X11 server.
Instead connections are normally made over unix sockets. 

NOTE: This alone is not sufficient to get linux working in most circumstances because X11 generally expects clients to authenticate with a token that the remote system does not have. 
(this can be worked around by running `xhost +local:` to allow non-network local connections without authentication for the lifetime of the current session or permanently by adding to /etc/x\<display number\>.hosts)