### PR TITLE
Add support for xauth

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -61,19 +61,6 @@
 							"Unix connects to an X11 server listening on a unix socket specified in `#remoteX11.X11Socket#`. This is generally nessasary for linux hosts."
 						]
 					},
-					"remoteX11.XAuthPermissionLevel": {
-						"type": "string",
-						"description": "Sets the permission level of this connection",
-						"default": "untrusted",
-						"enum": [
-							"untrusted",
-							"trusted"
-						],
-						"markdownEnumDescriptions": [
-							"Untrusted is the normal permission level",
-							"Trusted bypasses X11 security extention, allowing remote windows full access to other applications on the X11 server."
-						]
-					},
 					"remoteX11.X11Socket": {
 						"type": "string",
 						"markdownDescription": "Path to the X11 server unix socket. The screen number specified in `#remoteX11.screen#` is appended to the end. Used when `#remoteX11.X11ConnectionType#` is set to unix. ",

--- a/extension/package.json
+++ b/extension/package.json
@@ -61,6 +61,19 @@
 							"Unix connects to an X11 server listening on a unix socket specified in `#remoteX11.X11Socket#`. This is generally nessasary for linux hosts."
 						]
 					},
+					"remoteX11.XAuthPermissionLevel": {
+						"type": "string",
+						"description": "Sets the permission level of this connection",
+						"default": "untrusted",
+						"enum": [
+							"untrusted",
+							"trusted"
+						],
+						"markdownEnumDescriptions": [
+							"Untrusted is the normal permission level",
+							"Trusted bypasses X11 security extention, allowing remote windows full access to other applications on the X11 server."
+						]
+					},
 					"remoteX11.X11Socket": {
 						"type": "string",
 						"markdownDescription": "Path to the X11 server unix socket. The screen number specified in `#remoteX11.screen#` is appended to the end. Used when `#remoteX11.X11ConnectionType#` is set to unix. ",

--- a/ssh/package-lock.json
+++ b/ssh/package-lock.json
@@ -81,6 +81,12 @@
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 			"dev": true
 		},
+		"@types/command-exists": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@types/command-exists/-/command-exists-1.2.0.tgz",
+			"integrity": "sha512-ugsxEJfsCuqMLSuCD4PIJkp5Uk2z6TCMRCgYVuhRo5cYQY3+1xXTQkSlPtkpGHuvWMjS2KTeVQXxkXRACMbM6A==",
+			"dev": true
+		},
 		"@types/eslint-visitor-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1167,6 +1173,11 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
+		},
+		"command-exists": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+			"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
 		},
 		"commander": {
 			"version": "2.20.3",

--- a/ssh/package.json
+++ b/ssh/package.json
@@ -46,6 +46,19 @@
 			{
 				"title": "Remote X11",
 				"properties": {
+					"remoteX11.SSH.XAuthPermissionLevel": {
+						"type": "string",
+						"description": "Sets the permission level of this connection",
+						"default": "untrusted",
+						"enum": [
+							"untrusted",
+							"trusted"
+						],
+						"markdownEnumDescriptions": [
+							"Untrusted is the normal permission level",
+							"Trusted bypasses X11 security extention, allowing remote windows full access to other applications on the X11 server."
+						]
+					},
 					"remoteX11.SSH.authenticationMethod": {
 						"type": "string",
 						"description": "Sets how Remote X11 authenticates for SSH connections.",
@@ -115,6 +128,7 @@
 		"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {
+		"@types/command-exists": "^1.2.0",
 		"@types/glob": "^7.1.3",
 		"@types/mocha": "^8.0.0",
 		"@types/node": "^12.12.53",
@@ -140,6 +154,7 @@
 		"webpack-cli": "^3.3.12"
 	},
 	"dependencies": {
+		"command-exists": "^1.2.9",
 		"ssh2": "^0.8.9"
 	},
 	"prettier": {

--- a/ssh/src/config.ts
+++ b/ssh/src/config.ts
@@ -10,6 +10,8 @@ export type AuthenticationMethod = 'agent' | 'keyFile';
 
 export type X11ConnectionMethod = 'tcp' | 'unix';
 
+export type XAuthPermissionLevel = 'untrusted' | 'trusted';
+
 export function getConfig<T>(name: string, defaultValue: T): T {
 	const config = vscode.workspace.getConfiguration('remoteX11');
 	return config.get(name, defaultValue);
@@ -61,6 +63,10 @@ export function getX11ConnectionMethod(): X11ConnectionMethod {
 
 export function getX11SocketPath(): string {
 	return getConfig('X11Socket', "/tmp/.X11-unix/X");
+}
+
+export function getXAuthPermissionLevel(): XAuthPermissionLevel {
+	return getConfig<XAuthPermissionLevel>('XAuthPermissionLevel', 'untrusted');
 }
 
 function getDefaultAgent(): string {

--- a/ssh/src/config.ts
+++ b/ssh/src/config.ts
@@ -66,7 +66,7 @@ export function getX11SocketPath(): string {
 }
 
 export function getXAuthPermissionLevel(): XAuthPermissionLevel {
-	return getConfig<XAuthPermissionLevel>('XAuthPermissionLevel', 'untrusted');
+	return getConfig<XAuthPermissionLevel>('SSH.XAuthPermissionLevel', 'untrusted');
 }
 
 function getDefaultAgent(): string {


### PR DESCRIPTION
Support authenticating to the X11 server using MIT-MAGIC-COOKIE-1 tokens generated by xauth.
Fixes https://github.com/joelspadin/vscode-remote-x11/issues/21
